### PR TITLE
Fixed commit link only showing commits on branch named main

### DIFF
--- a/pages/neighborhood/[contributor]/[app].js
+++ b/pages/neighborhood/[contributor]/[app].js
@@ -277,7 +277,7 @@ export default function AppPage() {
                           if (match) {
                             const repo = match[2];
                             return (
-                              <span> (<a href={`https://github.com/${project.githubUsername}/${repo}/commits/main/?author=${project.githubUsername}`} target="_blank" rel="noopener noreferrer">Github Commits by @{project.githubUsername}</a>)</span>
+                              <span> (<a href={`https://github.com/${project.githubUsername}/${repo}/commits/?author=${project.githubUsername}`} target="_blank" rel="noopener noreferrer">Github Commits by @{project.githubUsername}</a>)</span>
                             );
                           }
                           // fallback to just githubLink


### PR DESCRIPTION
Hi,
On the project page, there's a link to the commit list in the git repo. However the link directs to a page with only the commits on the "main" branch. In some cases though, people's default branch might be called something else like "master". 
This PR just removes the name filter. The new link just show commits on the default branch of the repo.
Hope this helps, have good day!